### PR TITLE
fix(test): set psalm error level to 3 during acceptance tests

### DIFF
--- a/test/Integration/acceptance/PsrContainer.feature
+++ b/test/Integration/acceptance/PsrContainer.feature
@@ -7,7 +7,7 @@ Feature: PsrContainer
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm errorLevel="1">
+      <psalm errorLevel="3">
         <projectFiles>
           <directory name="."/>
         </projectFiles>


### PR DESCRIPTION
it's enough to check for invalid return types, and will avoid other unwanted errors like we currently have on PHP 8.3 tests with non typed class constants.